### PR TITLE
Add Telegram-flagged job application generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,11 @@ dist
 
 
 build/index.js
+
+# Database files
 tori.db
+data/*.db
+data/*.db-*
+
+# Generated job applications (CV-derived personal content)
+data/resumes/

--- a/build/reaction_listener.js
+++ b/build/reaction_listener.js
@@ -1,0 +1,113 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const dotenv_1 = require("dotenv");
+const logger_1 = require("./logger");
+const utils_1 = require("./utils");
+const reactions_db_1 = require("./reactions_db");
+/**
+ * Drains pending Telegram updates and flags job posts the user marked as
+ * interesting into the `posts` table. Designed to run once per day (not as a
+ * daemon): Telegram retains updates for 24h, so a daily run catches the day.
+ *
+ * Two trigger methods are supported:
+ *  1. REPLY (works in private DMs): reply to a job post's message. Any reply
+ *     flags it; a reply of exactly "-" un-flags it. This is the primary method
+ *     since reactions are NOT delivered to bots in private chats.
+ *  2. REACTION (groups/channels only, bot must be admin): 👍/❤️ etc. Channels
+ *     send anonymous `message_reaction_count`; groups send per-user
+ *     `message_reaction`.
+ *
+ * Requirement: no webhook / other getUpdates consumer may be active for the
+ * same bot, or updates will be split between consumers.
+ */
+const CRAWLER_NAME = 'reaction-listener';
+const logger = (0, logger_1.createLogger)(CRAWLER_NAME);
+// Emojis that count as a "like" worth generating an application for.
+const POSITIVE_EMOJIS = new Set(['👍', '❤️', '❤', '🔥', '👏']);
+const ALLOWED_UPDATES = ['message', 'message_reaction', 'message_reaction_count'];
+function countPositiveFromReactionCount(reactions) {
+    let total = 0;
+    for (const r of reactions || []) {
+        const emoji = r?.type?.emoji;
+        if (r?.type?.type === 'emoji' && emoji && POSITIVE_EMOJIS.has(emoji)) {
+            total += r.total_count || 0;
+        }
+    }
+    return total;
+}
+function countPositiveFromReactionList(reactions) {
+    let total = 0;
+    for (const r of reactions || []) {
+        const emoji = r?.emoji;
+        if (r?.type === 'emoji' && emoji && POSITIVE_EMOJIS.has(emoji)) {
+            total += 1;
+        }
+    }
+    return total;
+}
+(async () => {
+    (0, dotenv_1.config)();
+    const token = (0, utils_1.getTelegramToken)();
+    if (!token) {
+        logger.error('Telegram token not set (TELEGRAM_API_KEY or TELEGRAM_BOT_TOKEN); cannot poll for reactions');
+        process.exit(1);
+    }
+    const TelegramBot = require('node-telegram-bot-api');
+    const bot = new TelegramBot(token); // no polling: we drive getUpdates manually
+    const db = await (0, reactions_db_1.openDb)();
+    let offset = await (0, reactions_db_1.getOffset)(db);
+    logger.info('Starting reaction drain', { offset });
+    let totalUpdates = 0;
+    let matched = 0;
+    let unmatched = 0;
+    const MAX_BATCHES = 50; // safety cap
+    for (let batch = 0; batch < MAX_BATCHES; batch++) {
+        let updates;
+        try {
+            updates = await bot.getUpdates({ offset, limit: 100, timeout: 10, allowed_updates: ALLOWED_UPDATES });
+        }
+        catch (error) {
+            logger.error('getUpdates failed', { error: error?.message || String(error) });
+            break;
+        }
+        if (!updates || updates.length === 0)
+            break;
+        for (const update of updates) {
+            offset = update.update_id + 1;
+            totalUpdates++;
+            const rc = update.message_reaction_count;
+            const rx = update.message_reaction;
+            const msg = update.message;
+            let messageId;
+            let count;
+            if (rc) {
+                messageId = rc.message_id;
+                count = countPositiveFromReactionCount(rc.reactions);
+            }
+            else if (rx) {
+                messageId = rx.message_id;
+                count = countPositiveFromReactionList(rx.new_reaction);
+            }
+            else if (msg && msg.reply_to_message) {
+                // A reply to a tracked job post flags it (or un-flags it with "-").
+                messageId = msg.reply_to_message.message_id;
+                count = (msg.text || '').trim() === '-' ? 0 : 1;
+            }
+            if (messageId == null || count == null)
+                continue;
+            const changed = await (0, reactions_db_1.setReactionCount)(db, messageId, count);
+            if (changed > 0) {
+                matched++;
+                logger.info(count > 0 ? 'Flagged job post' : 'Un-flagged job post', { messageId, count });
+            }
+            else {
+                unmatched++;
+                logger.debug('Trigger on unknown message (not a tracked job post)', { messageId });
+            }
+        }
+        await (0, reactions_db_1.setOffset)(db, offset);
+    }
+    await (0, reactions_db_1.setOffset)(db, offset);
+    await db.close();
+    logger.info('Reaction drain complete', { totalUpdates, matched, unmatched, offset });
+})();

--- a/build/reactions_db.js
+++ b/build/reactions_db.js
@@ -1,0 +1,50 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.markResumeStatus = exports.getLikedPostsNeedingResume = exports.setReactionCount = exports.setOffset = exports.getOffset = exports.openDb = void 0;
+const sqlite3_1 = __importDefault(require("sqlite3"));
+const sqlite_1 = require("sqlite");
+const utils_1 = require("./utils");
+async function openDb() {
+    const db = await (0, sqlite_1.open)({ filename: (0, utils_1.getDbPath)(), driver: sqlite3_1.default.Database });
+    await db.exec(`CREATE TABLE IF NOT EXISTS posts (
+    message_id INTEGER PRIMARY KEY,
+    url TEXT,
+    chat_id TEXT,
+    posted_at TEXT,
+    reaction_count INTEGER DEFAULT 0,
+    resume_status TEXT DEFAULT 'pending'
+  )`);
+    await db.exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+    return db;
+}
+exports.openDb = openDb;
+async function getOffset(db) {
+    const row = await db.get("SELECT value FROM meta WHERE key = 'tg_offset'");
+    return row ? parseInt(row.value, 10) : 0;
+}
+exports.getOffset = getOffset;
+async function setOffset(db, offset) {
+    await db.run("INSERT OR REPLACE INTO meta (key, value) VALUES ('tg_offset', ?)", String(offset));
+}
+exports.setOffset = setOffset;
+/**
+ * Set the positive-reaction count for a post. Returns the number of rows
+ * updated (0 means we have no record of that message_id — e.g. a manual post).
+ */
+async function setReactionCount(db, messageId, count) {
+    const result = await db.run("UPDATE posts SET reaction_count = ? WHERE message_id = ?", count, messageId);
+    return result.changes ?? 0;
+}
+exports.setReactionCount = setReactionCount;
+/** Posts that have at least one positive reaction and no resume generated yet. */
+async function getLikedPostsNeedingResume(db) {
+    return db.all("SELECT * FROM posts WHERE reaction_count > 0 AND resume_status = 'pending' ORDER BY posted_at ASC");
+}
+exports.getLikedPostsNeedingResume = getLikedPostsNeedingResume;
+async function markResumeStatus(db, messageId, status) {
+    await db.run("UPDATE posts SET resume_status = ? WHERE message_id = ?", status, messageId);
+}
+exports.markResumeStatus = markResumeStatus;

--- a/build/resume_generator.js
+++ b/build/resume_generator.js
@@ -1,0 +1,227 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const playwright_1 = require("playwright");
+const dotenv_1 = require("dotenv");
+const fs_1 = require("fs");
+const path = __importStar(require("path"));
+const logger_1 = require("./logger");
+const utils_1 = require("./utils");
+const reactions_db_1 = require("./reactions_db");
+/**
+ * For each job post that received a positive reaction, scrape the job posting
+ * and the candidate's CV, generate a tailored application (resume + short cover
+ * letter) as markdown, save it under ./data/resumes/, and post it back to the
+ * Telegram channel.
+ *
+ * Tailoring uses the Anthropic API when ANTHROPIC_API_KEY is set; otherwise it
+ * falls back to a structured draft that bundles the CV and job posting so the
+ * work isn't lost.
+ */
+const CRAWLER_NAME = 'resume-generator';
+const logger = (0, logger_1.createLogger)(CRAWLER_NAME);
+const CV_URL = process.env.CV_URL || 'https://viitamäki.fi/cv_en.html';
+const RESUME_DIR = process.env.NODE_ENV === 'production' ? './data/resumes' : './data/resumes';
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6';
+const HEADLESS = true;
+/** Fetch the visible text of a page using a headless browser (handles IDN, JS). */
+async function fetchPageText(url) {
+    const browser = await playwright_1.chromium.launch({ headless: HEADLESS });
+    try {
+        const page = await browser.newPage();
+        await page.goto(url, { timeout: 30000, waitUntil: 'domcontentloaded' });
+        await page.waitForTimeout(2000);
+        // Prefer the <main> content to drop site nav/footer boilerplate; fall back
+        // to the full body if <main> is missing or suspiciously short.
+        let text = '';
+        const mainCount = await page.locator('main').count();
+        if (mainCount > 0) {
+            text = await page.locator('main').first().innerText().catch(() => '');
+        }
+        if (!text || text.trim().length < 200) {
+            text = await page.locator('body').innerText();
+        }
+        return (text || '').replace(/\n{3,}/g, '\n\n').trim();
+    }
+    finally {
+        await browser.close();
+    }
+}
+/** Call the Anthropic Messages API via fetch (no SDK dependency). */
+async function generateWithLLM(cvText, jobText, jobUrl) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey)
+        return null;
+    const prompt = `You are helping a candidate apply for a job. Using the candidate's CV and the job posting below, write a tailored, one-page application as GitHub-flavored markdown.
+
+Requirements:
+- Match the language of the JOB POSTING (Finnish posting -> Finnish output, English -> English).
+- Start with a short, specific cover letter (3-4 paragraphs) connecting the candidate's real experience to this role's requirements. Do NOT invent skills not present in the CV.
+- Follow with a concise tailored resume: summary, most-relevant skills, and the most-relevant experience for THIS role.
+- Be concrete, reference specifics from the posting, and keep it honest to the CV.
+
+=== CANDIDATE CV ===
+${cvText}
+
+=== JOB POSTING (${jobUrl}) ===
+${jobText}`;
+    // fetch is a Node 18+ global but not in the ES2020 lib typings; access via globalThis.
+    const fetchFn = globalThis.fetch;
+    if (typeof fetchFn !== 'function') {
+        logger.error('global fetch not available (requires Node 18+)');
+        return null;
+    }
+    try {
+        const res = await fetchFn('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+                'x-api-key': apiKey,
+                'anthropic-version': '2023-06-01',
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+                model: ANTHROPIC_MODEL,
+                max_tokens: 2000,
+                messages: [{ role: 'user', content: prompt }],
+            }),
+        });
+        if (!res.ok) {
+            logger.error('Anthropic API error', { status: res.status, body: await res.text() });
+            return null;
+        }
+        const data = await res.json();
+        const text = data?.content?.[0]?.text;
+        return typeof text === 'string' ? text : null;
+    }
+    catch (error) {
+        logger.error('Anthropic API call failed', { error: error?.message || String(error) });
+        return null;
+    }
+}
+/** Fallback draft when no LLM is available: bundle CV + posting for manual editing. */
+function buildFallbackDraft(cvText, jobText, jobUrl) {
+    return `# Application draft
+
+> Auto-generated draft (no ANTHROPIC_API_KEY set, so this was not tailored automatically).
+> Job: ${jobUrl}
+
+## Job posting
+
+${jobText}
+
+## Candidate CV (source: ${CV_URL})
+
+${cvText}
+`;
+}
+/**
+ * Resume generation only makes sense for job postings. The flag (reply/reaction)
+ * mechanism is generic across all crawler posts, so we skip non-job URLs (e.g.
+ * tori.fi / fillaritori.fi marketplace listings).
+ */
+function isJobUrl(url) {
+    return /duunitori\.fi\/tyopaikat/.test(url)
+        || /tyomarkkinatori\.fi/.test(url)
+        || /mol\.fi/.test(url);
+}
+function slugify(input) {
+    return input
+        .toLowerCase()
+        .replace(/https?:\/\//, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80) || 'job';
+}
+async function processPost(cvText, post) {
+    logger.info('Generating application', { messageId: post.message_id, url: post.url, reactions: post.reaction_count });
+    const jobText = await fetchPageText(post.url);
+    if (!jobText || jobText.length < 50) {
+        logger.warn('Job posting text too short, skipping', { url: post.url, length: jobText.length });
+        return;
+    }
+    let markdown = await generateWithLLM(cvText, jobText, post.url);
+    const tailored = markdown != null;
+    if (!markdown) {
+        logger.warn('Falling back to non-tailored draft (no LLM available)');
+        markdown = buildFallbackDraft(cvText, jobText, post.url);
+    }
+    const date = new Date().toISOString().slice(0, 10);
+    const fileName = `${date}-${slugify(post.url)}.md`;
+    const filePath = path.join(RESUME_DIR, fileName);
+    await fs_1.promises.mkdir(RESUME_DIR, { recursive: true });
+    await fs_1.promises.writeFile(filePath, markdown, 'utf-8');
+    logger.info('Saved resume', { filePath, tailored });
+    if ((0, utils_1.isTelegramConfigured)()) {
+        const caption = `📄 Application draft for a liked job post${tailored ? '' : ' (untailored — set ANTHROPIC_API_KEY)'}\n${post.url}`;
+        try {
+            await (0, utils_1.sendTelegramDocument)(filePath, caption.slice(0, 1024));
+        }
+        catch (error) {
+            logger.error('Failed to send resume document, sending notice instead', { error: error?.message });
+            await (0, utils_1.sendTelegramMessage)(`Generated application for ${post.url} but failed to upload the file.`).catch(() => { });
+        }
+    }
+    else {
+        logger.warn('Telegram not configured; resume saved locally only', { filePath });
+    }
+}
+(async () => {
+    (0, dotenv_1.config)();
+    const db = await (0, reactions_db_1.openDb)();
+    const posts = await (0, reactions_db_1.getLikedPostsNeedingResume)(db);
+    if (posts.length === 0) {
+        logger.info('No liked posts awaiting an application');
+        await db.close();
+        return;
+    }
+    logger.info('Liked posts to process', { count: posts.length });
+    let cvText;
+    try {
+        cvText = await fetchPageText(CV_URL);
+        logger.info('Fetched CV', { url: CV_URL, length: cvText.length });
+    }
+    catch (error) {
+        logger.error('Failed to fetch CV; aborting', { url: CV_URL, error: error?.message || String(error) });
+        await db.close();
+        process.exit(1);
+    }
+    for (const post of posts) {
+        if (!isJobUrl(post.url)) {
+            logger.info('Skipping non-job post (resume only applies to job postings)', { messageId: post.message_id, url: post.url });
+            await (0, reactions_db_1.markResumeStatus)(db, post.message_id, 'skipped');
+            continue;
+        }
+        try {
+            await processPost(cvText, post);
+            await (0, reactions_db_1.markResumeStatus)(db, post.message_id, 'done');
+        }
+        catch (error) {
+            logger.error('Failed to process post', { url: post.url, error: error?.message || String(error) });
+            await (0, reactions_db_1.markResumeStatus)(db, post.message_id, 'error');
+        }
+    }
+    await db.close();
+    logger.info('Resume generation complete');
+})();

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,11 +1,20 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.storeDb = void 0;
+exports.storeDb = exports.isTelegramConfigured = exports.sendTelegramDocument = exports.sendTelegramMessage = exports.getDbPath = exports.getTelegramToken = void 0;
 const sqlite3_1 = require("sqlite3");
 const logger_1 = require("./logger");
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+/**
+ * The Telegram bot token, accepting either TELEGRAM_API_KEY (used in code/docs)
+ * or TELEGRAM_BOT_TOKEN (used in some .env files) so the two never silently
+ * disagree.
+ */
+function getTelegramToken() {
+    return process.env.TELEGRAM_API_KEY || process.env.TELEGRAM_BOT_TOKEN;
+}
+exports.getTelegramToken = getTelegramToken;
 // Telegram rate limiting implementation
 class TelegramNotifier {
     constructor() {
@@ -14,10 +23,11 @@ class TelegramNotifier {
         this.RATE_LIMIT_DELAY = 1000; // 1 second between messages (Telegram allows 30 msg/sec for group, but we'll be conservative)
         this.MAX_RETRIES = 3;
         this.RETRY_DELAY = 5000; // 5 seconds delay on rate limit error
-        if (process.env.TELEGRAM_API_KEY) {
+        const token = getTelegramToken();
+        if (token) {
             try {
                 const TelegramBot = require('node-telegram-bot-api');
-                this.bot = new TelegramBot(process.env.TELEGRAM_API_KEY);
+                this.bot = new TelegramBot(token);
                 logger_1.logger.info("Telegram bot initialized successfully");
             }
             catch (error) {
@@ -26,21 +36,52 @@ class TelegramNotifier {
             }
         }
         else {
-            logger_1.logger.warn("TELEGRAM_API_KEY not found in environment variables");
+            logger_1.logger.warn("Telegram token not found (set TELEGRAM_API_KEY or TELEGRAM_BOT_TOKEN)");
         }
     }
-    async sendMessage(message) {
-        if (!this.bot) {
-            logger_1.logger.debug("Telegram bot not configured, skipping notification", { message });
-            return;
+    isConfigured() {
+        return !!this.bot && !!process.env.TELEGRAM_CHAT_ID;
+    }
+    /**
+     * Queue a text message for sending. Resolves with the Telegram message_id of
+     * the sent message (needed to map reactions back to job postings), or null if
+     * the bot is not configured.
+     */
+    sendMessage(message) {
+        return new Promise((resolve, reject) => {
+            if (!this.bot) {
+                logger_1.logger.debug("Telegram bot not configured, skipping notification", { message });
+                resolve(null);
+                return;
+            }
+            if (!process.env.TELEGRAM_CHAT_ID) {
+                logger_1.logger.debug("Telegram chat ID not configured, skipping notification", { message });
+                resolve(null);
+                return;
+            }
+            this.messageQueue.push({ text: message, resolve, reject });
+            if (!this.isProcessing) {
+                this.processQueue();
+            }
+        });
+    }
+    /**
+     * Send a document (e.g. a generated resume markdown file) directly, bypassing
+     * the text queue. Resolves with the message_id or null if not configured.
+     */
+    async sendDocument(filePath, caption) {
+        if (!this.isConfigured()) {
+            logger_1.logger.debug("Telegram bot not configured, skipping document", { filePath });
+            return null;
         }
-        if (!process.env.TELEGRAM_CHAT_ID) {
-            logger_1.logger.debug("Telegram chat ID not configured, skipping notification", { message });
-            return;
+        try {
+            const result = await this.bot.sendDocument(process.env.TELEGRAM_CHAT_ID, filePath, caption ? { caption } : {});
+            logger_1.logger.info("Telegram document sent", { filePath });
+            return result?.message_id ?? null;
         }
-        this.messageQueue.push(message);
-        if (!this.isProcessing) {
-            this.processQueue();
+        catch (error) {
+            logger_1.logger.error("Failed to send Telegram document", { filePath, error: error.message });
+            throw error;
         }
     }
     async processQueue() {
@@ -49,27 +90,29 @@ class TelegramNotifier {
             return;
         }
         this.isProcessing = true;
-        const message = this.messageQueue.shift();
+        const item = this.messageQueue.shift();
         try {
-            await this.sendWithRetry(message);
-            // Wait before processing next message
-            if (this.messageQueue.length > 0) {
-                await sleep(this.RATE_LIMIT_DELAY);
-                this.processQueue();
-            }
-            else {
-                this.isProcessing = false;
-            }
+            const messageId = await this.sendWithRetry(item.text);
+            item.resolve(messageId);
         }
         catch (error) {
-            logger_1.logger.error("Failed to send Telegram message after retries", { message, error: error instanceof Error ? error.message : String(error) });
+            logger_1.logger.error("Failed to send Telegram message after retries", { message: item.text, error: error instanceof Error ? error.message : String(error) });
+            item.reject(error);
+        }
+        // Continue draining the queue regardless of individual message outcome
+        if (this.messageQueue.length > 0) {
+            await sleep(this.RATE_LIMIT_DELAY);
+            this.processQueue();
+        }
+        else {
             this.isProcessing = false;
         }
     }
     async sendWithRetry(message, retries = 0) {
         try {
-            await this.bot.sendMessage(process.env.TELEGRAM_CHAT_ID, message);
+            const result = await this.bot.sendMessage(process.env.TELEGRAM_CHAT_ID, message);
             logger_1.logger.info("Telegram notification sent", { message });
+            return result?.message_id ?? null;
         }
         catch (error) {
             logger_1.logger.error("Telegram API error", { error: error.message });
@@ -105,6 +148,29 @@ function getTelegramNotifier() {
     }
     return telegramNotifier;
 }
+/**
+ * Resolve the SQLite database path. Uses ./data/tori.db in production
+ * (systemd / Docker) and ./tori.db for local development.
+ */
+function getDbPath() {
+    return process.env.NODE_ENV === 'production' ? './data/tori.db' : './tori.db';
+}
+exports.getDbPath = getDbPath;
+/** Queue a Telegram text message. Resolves with the sent message_id (or null). */
+function sendTelegramMessage(message) {
+    return getTelegramNotifier().sendMessage(message);
+}
+exports.sendTelegramMessage = sendTelegramMessage;
+/** Send a document (e.g. a resume markdown file) to the configured chat. */
+function sendTelegramDocument(filePath, caption) {
+    return getTelegramNotifier().sendDocument(filePath, caption);
+}
+exports.sendTelegramDocument = sendTelegramDocument;
+/** Whether Telegram credentials are present and the bot initialized. */
+function isTelegramConfigured() {
+    return getTelegramNotifier().isConfigured();
+}
+exports.isTelegramConfigured = isTelegramConfigured;
 async function openUrlInBrowser(url) {
     const { exec } = require('child_process');
     const { promisify } = require('util');
@@ -154,7 +220,7 @@ async function storeDb(urls, openInBrowser = false, skipDatabase = false) {
     // Normal database storage mode
     return new Promise((resolve, reject) => {
         // Store database in data directory for persistence in Docker
-        const dbPath = process.env.NODE_ENV === 'production' ? './data/tori.db' : './tori.db';
+        const dbPath = getDbPath();
         const db = new sqlite3_1.Database(dbPath, sqlite3_1.OPEN_READWRITE | sqlite3_1.OPEN_CREATE, (err) => {
             if (err) {
                 logger_1.logger.error("Database connection error", { error: err.message });
@@ -162,70 +228,98 @@ async function storeDb(urls, openInBrowser = false, skipDatabase = false) {
                 return;
             }
             logger_1.logger.info("Connected to Database");
-            db.run("CREATE TABLE IF NOT EXISTS links (url TEXT UNIQUE)", (err) => {
-                if (err) {
-                    logger_1.logger.error("Error creating table", { error: err.message });
-                    reject(err);
-                    return;
-                }
-                const stmt = db.prepare("INSERT INTO links VALUES (?)");
-                let processedCount = 0;
-                const totalCount = urls.length;
-                const asyncOperations = [];
-                if (totalCount === 0) {
-                    logger_1.logger.info("No URLs to process");
-                    resolve();
-                    return;
-                }
-                urls.forEach((url) => {
-                    stmt.run(url, (err) => {
-                        processedCount++;
-                        if (err) {
-                            logger_1.logger.debug("Database error (likely duplicate)", { error: err.message });
-                            logger_1.logger.debug("URL already in database", { url });
-                        }
-                        else {
-                            logger_1.logger.info("Added new URL to database", { url });
-                            // Send notification for new URLs only using rate-limited system
-                            const telegramPromise = getTelegramNotifier().sendMessage(url).catch((telegramError) => {
-                                logger_1.logger.error("Failed to send Telegram notification", { url, error: telegramError instanceof Error ? telegramError.message : String(telegramError) });
-                            });
-                            asyncOperations.push(telegramPromise);
-                            // Open URL in browser if flag is set
-                            if (openInBrowser) {
-                                const browserPromise = openUrlInBrowser(url).catch((browserError) => {
-                                    logger_1.logger.error("Failed to open URL in browser", { url, error: browserError instanceof Error ? browserError.message : String(browserError) });
-                                });
-                                asyncOperations.push(browserPromise);
+            db.serialize(() => {
+                // posts maps each Telegram message_id back to the job URL it announced,
+                // so the reaction listener can tie a 👍/❤️ on a post to its job posting.
+                db.run(`CREATE TABLE IF NOT EXISTS posts (
+          message_id INTEGER PRIMARY KEY,
+          url TEXT,
+          chat_id TEXT,
+          posted_at TEXT,
+          reaction_count INTEGER DEFAULT 0,
+          resume_status TEXT DEFAULT 'pending'
+        )`, (postsErr) => {
+                    if (postsErr) {
+                        logger_1.logger.error("Error creating posts table", { error: postsErr.message });
+                    }
+                });
+                db.run("CREATE TABLE IF NOT EXISTS links (url TEXT UNIQUE)", (err) => {
+                    if (err) {
+                        logger_1.logger.error("Error creating table", { error: err.message });
+                        reject(err);
+                        return;
+                    }
+                    const stmt = db.prepare("INSERT INTO links VALUES (?)");
+                    let processedCount = 0;
+                    const totalCount = urls.length;
+                    const asyncOperations = [];
+                    if (totalCount === 0) {
+                        logger_1.logger.info("No URLs to process");
+                        resolve();
+                        return;
+                    }
+                    urls.forEach((url) => {
+                        stmt.run(url, (err) => {
+                            processedCount++;
+                            if (err) {
+                                logger_1.logger.debug("Database error (likely duplicate)", { error: err.message });
+                                logger_1.logger.debug("URL already in database", { url });
                             }
-                        }
-                        // Check if all URLs have been processed
-                        if (processedCount === totalCount) {
-                            // Wait for all async operations to complete before finalizing
-                            Promise.all(asyncOperations).finally(() => {
-                                stmt.finalize((finalizeErr) => {
-                                    if (finalizeErr) {
-                                        logger_1.logger.error("Error finalizing statement", { error: finalizeErr.message });
-                                        reject(finalizeErr);
-                                    }
-                                    else {
-                                        logger_1.logger.info("Database operations completed", { processedCount: totalCount });
-                                        db.close((closeErr) => {
-                                            if (closeErr) {
-                                                logger_1.logger.error("Error closing database", { error: closeErr.message });
-                                                reject(closeErr);
-                                            }
-                                            else {
-                                                resolve();
-                                            }
-                                        });
-                                    }
+                            else {
+                                logger_1.logger.info("Added new URL to database", { url });
+                                // Send notification for new URLs only using rate-limited system.
+                                // Record the resulting message_id so reactions on this post can
+                                // later be mapped back to the job URL.
+                                const telegramPromise = getTelegramNotifier().sendMessage(url)
+                                    .then((messageId) => {
+                                    if (messageId == null)
+                                        return;
+                                    db.run("INSERT OR REPLACE INTO posts (message_id, url, chat_id, posted_at) VALUES (?, ?, ?, ?)", [messageId, url, process.env.TELEGRAM_CHAT_ID || null, new Date().toISOString()], (postErr) => {
+                                        if (postErr) {
+                                            logger_1.logger.error("Failed to record post mapping", { url, messageId, error: postErr.message });
+                                        }
+                                    });
+                                })
+                                    .catch((telegramError) => {
+                                    logger_1.logger.error("Failed to send Telegram notification", { url, error: telegramError instanceof Error ? telegramError.message : String(telegramError) });
                                 });
-                            });
-                        }
+                                asyncOperations.push(telegramPromise);
+                                // Open URL in browser if flag is set
+                                if (openInBrowser) {
+                                    const browserPromise = openUrlInBrowser(url).catch((browserError) => {
+                                        logger_1.logger.error("Failed to open URL in browser", { url, error: browserError instanceof Error ? browserError.message : String(browserError) });
+                                    });
+                                    asyncOperations.push(browserPromise);
+                                }
+                            }
+                            // Check if all URLs have been processed
+                            if (processedCount === totalCount) {
+                                // Wait for all async operations to complete before finalizing
+                                Promise.all(asyncOperations).finally(() => {
+                                    stmt.finalize((finalizeErr) => {
+                                        if (finalizeErr) {
+                                            logger_1.logger.error("Error finalizing statement", { error: finalizeErr.message });
+                                            reject(finalizeErr);
+                                        }
+                                        else {
+                                            logger_1.logger.info("Database operations completed", { processedCount: totalCount });
+                                            db.close((closeErr) => {
+                                                if (closeErr) {
+                                                    logger_1.logger.error("Error closing database", { error: closeErr.message });
+                                                    reject(closeErr);
+                                                }
+                                                else {
+                                                    resolve();
+                                                }
+                                            });
+                                        }
+                                    });
+                                });
+                            }
+                        });
                     });
                 });
-            });
+            }); // end db.serialize
         });
     });
 }

--- a/env.example
+++ b/env.example
@@ -2,4 +2,12 @@
 TELEGRAM_API_KEY=your_telegram_api_key
 TELEGRAM_CHAT_ID=your_telegram_chat_id
 
+# Resume generator (optional)
+# If set, applications are tailored via the Anthropic API; otherwise an
+# untailored draft (CV + job posting) is produced instead.
+ANTHROPIC_API_KEY=your_anthropic_api_key
+# Override the model or CV source if needed:
+# ANTHROPIC_MODEL=claude-sonnet-4-6
+# CV_URL=https://viitamäki.fi/cv_en.html
+
 # Add other environment variables as needed

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "start": "node build/tori_crawler.js",
     "start:mol": "node build/mol_crawler.js",
     "start:duunitori": "node build/duunitori_crawler.js",
+    "reactions": "node build/reaction_listener.js",
+    "resumes": "node build/resume_generator.js",
     "test": "playwright test"
   }
 }

--- a/src/reaction_listener.ts
+++ b/src/reaction_listener.ts
@@ -1,0 +1,126 @@
+import { config } from 'dotenv';
+import { createLogger } from './logger';
+import { getTelegramToken } from './utils';
+import { openDb, getOffset, setOffset, setReactionCount } from './reactions_db';
+
+/**
+ * Drains pending Telegram updates and flags job posts the user marked as
+ * interesting into the `posts` table. Designed to run once per day (not as a
+ * daemon): Telegram retains updates for 24h, so a daily run catches the day.
+ *
+ * Two trigger methods are supported:
+ *  1. REPLY (works in private DMs): reply to a job post's message. Any reply
+ *     flags it; a reply of exactly "-" un-flags it. This is the primary method
+ *     since reactions are NOT delivered to bots in private chats.
+ *  2. REACTION (groups/channels only, bot must be admin): 👍/❤️ etc. Channels
+ *     send anonymous `message_reaction_count`; groups send per-user
+ *     `message_reaction`.
+ *
+ * Requirement: no webhook / other getUpdates consumer may be active for the
+ * same bot, or updates will be split between consumers.
+ */
+
+const CRAWLER_NAME = 'reaction-listener';
+const logger = createLogger(CRAWLER_NAME);
+
+// Emojis that count as a "like" worth generating an application for.
+const POSITIVE_EMOJIS = new Set(['👍', '❤️', '❤', '🔥', '👏']);
+
+const ALLOWED_UPDATES = ['message', 'message_reaction', 'message_reaction_count'];
+
+function countPositiveFromReactionCount(reactions: any[]): number {
+  let total = 0;
+  for (const r of reactions || []) {
+    const emoji = r?.type?.emoji;
+    if (r?.type?.type === 'emoji' && emoji && POSITIVE_EMOJIS.has(emoji)) {
+      total += r.total_count || 0;
+    }
+  }
+  return total;
+}
+
+function countPositiveFromReactionList(reactions: any[]): number {
+  let total = 0;
+  for (const r of reactions || []) {
+    const emoji = r?.emoji;
+    if (r?.type === 'emoji' && emoji && POSITIVE_EMOJIS.has(emoji)) {
+      total += 1;
+    }
+  }
+  return total;
+}
+
+(async () => {
+  config();
+
+  const token = getTelegramToken();
+  if (!token) {
+    logger.error('Telegram token not set (TELEGRAM_API_KEY or TELEGRAM_BOT_TOKEN); cannot poll for reactions');
+    process.exit(1);
+  }
+
+  const TelegramBot = require('node-telegram-bot-api');
+  const bot = new TelegramBot(token); // no polling: we drive getUpdates manually
+
+  const db = await openDb();
+  let offset = await getOffset(db);
+  logger.info('Starting reaction drain', { offset });
+
+  let totalUpdates = 0;
+  let matched = 0;
+  let unmatched = 0;
+  const MAX_BATCHES = 50; // safety cap
+
+  for (let batch = 0; batch < MAX_BATCHES; batch++) {
+    let updates: any[];
+    try {
+      updates = await bot.getUpdates({ offset, limit: 100, timeout: 10, allowed_updates: ALLOWED_UPDATES });
+    } catch (error: any) {
+      logger.error('getUpdates failed', { error: error?.message || String(error) });
+      break;
+    }
+
+    if (!updates || updates.length === 0) break;
+
+    for (const update of updates) {
+      offset = update.update_id + 1;
+      totalUpdates++;
+
+      const rc = update.message_reaction_count;
+      const rx = update.message_reaction;
+      const msg = update.message;
+
+      let messageId: number | undefined;
+      let count: number | undefined;
+
+      if (rc) {
+        messageId = rc.message_id;
+        count = countPositiveFromReactionCount(rc.reactions);
+      } else if (rx) {
+        messageId = rx.message_id;
+        count = countPositiveFromReactionList(rx.new_reaction);
+      } else if (msg && msg.reply_to_message) {
+        // A reply to a tracked job post flags it (or un-flags it with "-").
+        messageId = msg.reply_to_message.message_id;
+        count = (msg.text || '').trim() === '-' ? 0 : 1;
+      }
+
+      if (messageId == null || count == null) continue;
+
+      const changed = await setReactionCount(db, messageId, count);
+      if (changed > 0) {
+        matched++;
+        logger.info(count > 0 ? 'Flagged job post' : 'Un-flagged job post', { messageId, count });
+      } else {
+        unmatched++;
+        logger.debug('Trigger on unknown message (not a tracked job post)', { messageId });
+      }
+    }
+
+    await setOffset(db, offset);
+  }
+
+  await setOffset(db, offset);
+  await db.close();
+  logger.info('Reaction drain complete', { totalUpdates, matched, unmatched, offset });
+})();

--- a/src/reactions_db.ts
+++ b/src/reactions_db.ts
@@ -1,0 +1,65 @@
+import sqlite3 from 'sqlite3';
+import { open, Database } from 'sqlite';
+import { getDbPath } from './utils';
+
+/**
+ * Shared, promise-based access to the `posts` table that links Telegram
+ * message_ids to job URLs, plus a small `meta` key/value store used to persist
+ * the Telegram getUpdates offset between listener runs.
+ *
+ * The `posts` table is created by storeDb() in utils.ts when crawlers post
+ * listings; we (re)create it defensively here so the listener/generator can run
+ * standalone against a fresh database.
+ */
+
+export interface PostRow {
+  message_id: number;
+  url: string;
+  chat_id: string | null;
+  posted_at: string | null;
+  reaction_count: number;
+  resume_status: string;
+}
+
+export async function openDb(): Promise<Database> {
+  const db = await open({ filename: getDbPath(), driver: sqlite3.Database });
+  await db.exec(`CREATE TABLE IF NOT EXISTS posts (
+    message_id INTEGER PRIMARY KEY,
+    url TEXT,
+    chat_id TEXT,
+    posted_at TEXT,
+    reaction_count INTEGER DEFAULT 0,
+    resume_status TEXT DEFAULT 'pending'
+  )`);
+  await db.exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+  return db;
+}
+
+export async function getOffset(db: Database): Promise<number> {
+  const row = await db.get<{ value: string }>("SELECT value FROM meta WHERE key = 'tg_offset'");
+  return row ? parseInt(row.value, 10) : 0;
+}
+
+export async function setOffset(db: Database, offset: number): Promise<void> {
+  await db.run("INSERT OR REPLACE INTO meta (key, value) VALUES ('tg_offset', ?)", String(offset));
+}
+
+/**
+ * Set the positive-reaction count for a post. Returns the number of rows
+ * updated (0 means we have no record of that message_id — e.g. a manual post).
+ */
+export async function setReactionCount(db: Database, messageId: number, count: number): Promise<number> {
+  const result = await db.run("UPDATE posts SET reaction_count = ? WHERE message_id = ?", count, messageId);
+  return result.changes ?? 0;
+}
+
+/** Posts that have at least one positive reaction and no resume generated yet. */
+export async function getLikedPostsNeedingResume(db: Database): Promise<PostRow[]> {
+  return db.all<PostRow[]>(
+    "SELECT * FROM posts WHERE reaction_count > 0 AND resume_status = 'pending' ORDER BY posted_at ASC"
+  );
+}
+
+export async function markResumeStatus(db: Database, messageId: number, status: string): Promise<void> {
+  await db.run("UPDATE posts SET resume_status = ? WHERE message_id = ?", status, messageId);
+}

--- a/src/resume_generator.ts
+++ b/src/resume_generator.ts
@@ -1,0 +1,219 @@
+import { chromium } from 'playwright';
+import { config } from 'dotenv';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { createLogger } from './logger';
+import { sendTelegramMessage, sendTelegramDocument, isTelegramConfigured } from './utils';
+import { openDb, getLikedPostsNeedingResume, markResumeStatus, PostRow } from './reactions_db';
+
+/**
+ * For each job post that received a positive reaction, scrape the job posting
+ * and the candidate's CV, generate a tailored application (resume + short cover
+ * letter) as markdown, save it under ./data/resumes/, and post it back to the
+ * Telegram channel.
+ *
+ * Tailoring uses the Anthropic API when ANTHROPIC_API_KEY is set; otherwise it
+ * falls back to a structured draft that bundles the CV and job posting so the
+ * work isn't lost.
+ */
+
+const CRAWLER_NAME = 'resume-generator';
+const logger = createLogger(CRAWLER_NAME);
+
+const CV_URL = process.env.CV_URL || 'https://viitamäki.fi/cv_en.html';
+const RESUME_DIR = process.env.NODE_ENV === 'production' ? './data/resumes' : './data/resumes';
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6';
+const HEADLESS = true;
+
+/** Fetch the visible text of a page using a headless browser (handles IDN, JS). */
+async function fetchPageText(url: string): Promise<string> {
+  const browser = await chromium.launch({ headless: HEADLESS });
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { timeout: 30000, waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2000);
+    // Prefer the <main> content to drop site nav/footer boilerplate; fall back
+    // to the full body if <main> is missing or suspiciously short.
+    let text = '';
+    const mainCount = await page.locator('main').count();
+    if (mainCount > 0) {
+      text = await page.locator('main').first().innerText().catch(() => '');
+    }
+    if (!text || text.trim().length < 200) {
+      text = await page.locator('body').innerText();
+    }
+    return (text || '').replace(/\n{3,}/g, '\n\n').trim();
+  } finally {
+    await browser.close();
+  }
+}
+
+/** Call the Anthropic Messages API via fetch (no SDK dependency). */
+async function generateWithLLM(cvText: string, jobText: string, jobUrl: string): Promise<string | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+
+  const prompt = `You are helping a candidate apply for a job. Using the candidate's CV and the job posting below, write a tailored, one-page application as GitHub-flavored markdown.
+
+Requirements:
+- Match the language of the JOB POSTING (Finnish posting -> Finnish output, English -> English).
+- Start with a short, specific cover letter (3-4 paragraphs) connecting the candidate's real experience to this role's requirements. Do NOT invent skills not present in the CV.
+- Follow with a concise tailored resume: summary, most-relevant skills, and the most-relevant experience for THIS role.
+- Be concrete, reference specifics from the posting, and keep it honest to the CV.
+
+=== CANDIDATE CV ===
+${cvText}
+
+=== JOB POSTING (${jobUrl}) ===
+${jobText}`;
+
+  // fetch is a Node 18+ global but not in the ES2020 lib typings; access via globalThis.
+  const fetchFn: any = (globalThis as any).fetch;
+  if (typeof fetchFn !== 'function') {
+    logger.error('global fetch not available (requires Node 18+)');
+    return null;
+  }
+
+  try {
+    const res = await fetchFn('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    if (!res.ok) {
+      logger.error('Anthropic API error', { status: res.status, body: await res.text() });
+      return null;
+    }
+    const data: any = await res.json();
+    const text = data?.content?.[0]?.text;
+    return typeof text === 'string' ? text : null;
+  } catch (error: any) {
+    logger.error('Anthropic API call failed', { error: error?.message || String(error) });
+    return null;
+  }
+}
+
+/** Fallback draft when no LLM is available: bundle CV + posting for manual editing. */
+function buildFallbackDraft(cvText: string, jobText: string, jobUrl: string): string {
+  return `# Application draft
+
+> Auto-generated draft (no ANTHROPIC_API_KEY set, so this was not tailored automatically).
+> Job: ${jobUrl}
+
+## Job posting
+
+${jobText}
+
+## Candidate CV (source: ${CV_URL})
+
+${cvText}
+`;
+}
+
+/**
+ * Resume generation only makes sense for job postings. The flag (reply/reaction)
+ * mechanism is generic across all crawler posts, so we skip non-job URLs (e.g.
+ * tori.fi / fillaritori.fi marketplace listings).
+ */
+function isJobUrl(url: string): boolean {
+  return /duunitori\.fi\/tyopaikat/.test(url)
+    || /tyomarkkinatori\.fi/.test(url)
+    || /mol\.fi/.test(url);
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'job';
+}
+
+async function processPost(cvText: string, post: PostRow): Promise<void> {
+  logger.info('Generating application', { messageId: post.message_id, url: post.url, reactions: post.reaction_count });
+
+  const jobText = await fetchPageText(post.url);
+  if (!jobText || jobText.length < 50) {
+    logger.warn('Job posting text too short, skipping', { url: post.url, length: jobText.length });
+    return;
+  }
+
+  let markdown = await generateWithLLM(cvText, jobText, post.url);
+  const tailored = markdown != null;
+  if (!markdown) {
+    logger.warn('Falling back to non-tailored draft (no LLM available)');
+    markdown = buildFallbackDraft(cvText, jobText, post.url);
+  }
+
+  const date = new Date().toISOString().slice(0, 10);
+  const fileName = `${date}-${slugify(post.url)}.md`;
+  const filePath = path.join(RESUME_DIR, fileName);
+  await fs.mkdir(RESUME_DIR, { recursive: true });
+  await fs.writeFile(filePath, markdown, 'utf-8');
+  logger.info('Saved resume', { filePath, tailored });
+
+  if (isTelegramConfigured()) {
+    const caption = `📄 Application draft for a liked job post${tailored ? '' : ' (untailored — set ANTHROPIC_API_KEY)'}\n${post.url}`;
+    try {
+      await sendTelegramDocument(filePath, caption.slice(0, 1024));
+    } catch (error: any) {
+      logger.error('Failed to send resume document, sending notice instead', { error: error?.message });
+      await sendTelegramMessage(`Generated application for ${post.url} but failed to upload the file.`).catch(() => {});
+    }
+  } else {
+    logger.warn('Telegram not configured; resume saved locally only', { filePath });
+  }
+}
+
+(async () => {
+  config();
+
+  const db = await openDb();
+  const posts = await getLikedPostsNeedingResume(db);
+
+  if (posts.length === 0) {
+    logger.info('No liked posts awaiting an application');
+    await db.close();
+    return;
+  }
+
+  logger.info('Liked posts to process', { count: posts.length });
+
+  let cvText: string;
+  try {
+    cvText = await fetchPageText(CV_URL);
+    logger.info('Fetched CV', { url: CV_URL, length: cvText.length });
+  } catch (error: any) {
+    logger.error('Failed to fetch CV; aborting', { url: CV_URL, error: error?.message || String(error) });
+    await db.close();
+    process.exit(1);
+  }
+
+  for (const post of posts) {
+    if (!isJobUrl(post.url)) {
+      logger.info('Skipping non-job post (resume only applies to job postings)', { messageId: post.message_id, url: post.url });
+      await markResumeStatus(db, post.message_id, 'skipped');
+      continue;
+    }
+    try {
+      await processPost(cvText, post);
+      await markResumeStatus(db, post.message_id, 'done');
+    } catch (error: any) {
+      logger.error('Failed to process post', { url: post.url, error: error?.message || String(error) });
+      await markResumeStatus(db, post.message_id, 'error');
+    }
+  }
+
+  await db.close();
+  logger.info('Resume generation complete');
+})();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,45 +5,96 @@ function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * The Telegram bot token, accepting either TELEGRAM_API_KEY (used in code/docs)
+ * or TELEGRAM_BOT_TOKEN (used in some .env files) so the two never silently
+ * disagree.
+ */
+export function getTelegramToken(): string | undefined {
+  return process.env.TELEGRAM_API_KEY || process.env.TELEGRAM_BOT_TOKEN;
+}
+
+interface QueuedMessage {
+  text: string;
+  resolve: (messageId: number | null) => void;
+  reject: (error: any) => void;
+}
+
 // Telegram rate limiting implementation
 class TelegramNotifier {
   private bot: any;
-  private messageQueue: string[] = [];
+  private messageQueue: QueuedMessage[] = [];
   private isProcessing = false;
   private readonly RATE_LIMIT_DELAY = 1000; // 1 second between messages (Telegram allows 30 msg/sec for group, but we'll be conservative)
   private readonly MAX_RETRIES = 3;
   private readonly RETRY_DELAY = 5000; // 5 seconds delay on rate limit error
 
   constructor() {
-    if (process.env.TELEGRAM_API_KEY) {
+    const token = getTelegramToken();
+    if (token) {
       try {
         const TelegramBot = require('node-telegram-bot-api');
-        this.bot = new TelegramBot(process.env.TELEGRAM_API_KEY);
+        this.bot = new TelegramBot(token);
         logger.info("Telegram bot initialized successfully");
       } catch (error) {
         logger.error("Failed to initialize Telegram bot", { error: error instanceof Error ? error.message : String(error) });
         this.bot = null;
       }
     } else {
-      logger.warn("TELEGRAM_API_KEY not found in environment variables");
+      logger.warn("Telegram token not found (set TELEGRAM_API_KEY or TELEGRAM_BOT_TOKEN)");
     }
   }
 
-  public async sendMessage(message: string): Promise<void> {
-    if (!this.bot) {
-      logger.debug("Telegram bot not configured, skipping notification", { message });
-      
-      return;
-    }
-    if (!process.env.TELEGRAM_CHAT_ID) {
-      logger.debug("Telegram chat ID not configured, skipping notification", { message });
-      return;
-    }
+  public isConfigured(): boolean {
+    return !!this.bot && !!process.env.TELEGRAM_CHAT_ID;
+  }
 
-    this.messageQueue.push(message);
-    
-    if (!this.isProcessing) {
-      this.processQueue();
+  /**
+   * Queue a text message for sending. Resolves with the Telegram message_id of
+   * the sent message (needed to map reactions back to job postings), or null if
+   * the bot is not configured.
+   */
+  public sendMessage(message: string): Promise<number | null> {
+    return new Promise((resolve, reject) => {
+      if (!this.bot) {
+        logger.debug("Telegram bot not configured, skipping notification", { message });
+        resolve(null);
+        return;
+      }
+      if (!process.env.TELEGRAM_CHAT_ID) {
+        logger.debug("Telegram chat ID not configured, skipping notification", { message });
+        resolve(null);
+        return;
+      }
+
+      this.messageQueue.push({ text: message, resolve, reject });
+
+      if (!this.isProcessing) {
+        this.processQueue();
+      }
+    });
+  }
+
+  /**
+   * Send a document (e.g. a generated resume markdown file) directly, bypassing
+   * the text queue. Resolves with the message_id or null if not configured.
+   */
+  public async sendDocument(filePath: string, caption?: string): Promise<number | null> {
+    if (!this.isConfigured()) {
+      logger.debug("Telegram bot not configured, skipping document", { filePath });
+      return null;
+    }
+    try {
+      const result = await this.bot.sendDocument(
+        process.env.TELEGRAM_CHAT_ID,
+        filePath,
+        caption ? { caption } : {}
+      );
+      logger.info("Telegram document sent", { filePath });
+      return result?.message_id ?? null;
+    } catch (error: any) {
+      logger.error("Failed to send Telegram document", { filePath, error: error.message });
+      throw error;
     }
   }
 
@@ -54,36 +105,38 @@ class TelegramNotifier {
     }
 
     this.isProcessing = true;
-    const message = this.messageQueue.shift()!;
+    const item = this.messageQueue.shift()!;
 
     try {
-      await this.sendWithRetry(message);
-      
-      // Wait before processing next message
-      if (this.messageQueue.length > 0) {
-        await sleep(this.RATE_LIMIT_DELAY);
-        this.processQueue();
-      } else {
-        this.isProcessing = false;
-      }
+      const messageId = await this.sendWithRetry(item.text);
+      item.resolve(messageId);
     } catch (error) {
-      logger.error("Failed to send Telegram message after retries", { message, error: error instanceof Error ? error.message : String(error) });
+      logger.error("Failed to send Telegram message after retries", { message: item.text, error: error instanceof Error ? error.message : String(error) });
+      item.reject(error);
+    }
+
+    // Continue draining the queue regardless of individual message outcome
+    if (this.messageQueue.length > 0) {
+      await sleep(this.RATE_LIMIT_DELAY);
+      this.processQueue();
+    } else {
       this.isProcessing = false;
     }
   }
 
-  private async sendWithRetry(message: string, retries: number = 0): Promise<void> {
+  private async sendWithRetry(message: string, retries: number = 0): Promise<number | null> {
     try {
-      await this.bot.sendMessage(process.env.TELEGRAM_CHAT_ID, message);
+      const result = await this.bot.sendMessage(process.env.TELEGRAM_CHAT_ID, message);
       logger.info("Telegram notification sent", { message });
+      return result?.message_id ?? null;
     } catch (error: any) {
       logger.error("Telegram API error", { error: error.message });
-      
+
       // Handle rate limiting specifically
       if (error.code === 429 || error.message.includes('Too Many Requests')) {
         const retryAfter = error.parameters?.retry_after || (this.RETRY_DELAY / 1000);
         logger.warn("Rate limited, waiting before retry", { retryAfter, attempt: retries + 1 });
-        
+
         if (retries < this.MAX_RETRIES) {
           await sleep(retryAfter * 1000);
           return this.sendWithRetry(message, retries + 1);
@@ -91,7 +144,7 @@ class TelegramNotifier {
           throw new Error(`Max retries exceeded for message: ${message}`);
         }
       }
-      
+
       // Handle other errors
       if (retries < this.MAX_RETRIES) {
         logger.warn("Retrying message send", { attempt: retries + 1, maxRetries: this.MAX_RETRIES });
@@ -112,6 +165,29 @@ function getTelegramNotifier(): TelegramNotifier {
     telegramNotifier = new TelegramNotifier();
   }
   return telegramNotifier;
+}
+
+/**
+ * Resolve the SQLite database path. Uses ./data/tori.db in production
+ * (systemd / Docker) and ./tori.db for local development.
+ */
+export function getDbPath(): string {
+  return process.env.NODE_ENV === 'production' ? './data/tori.db' : './tori.db';
+}
+
+/** Queue a Telegram text message. Resolves with the sent message_id (or null). */
+export function sendTelegramMessage(message: string): Promise<number | null> {
+  return getTelegramNotifier().sendMessage(message);
+}
+
+/** Send a document (e.g. a resume markdown file) to the configured chat. */
+export function sendTelegramDocument(filePath: string, caption?: string): Promise<number | null> {
+  return getTelegramNotifier().sendDocument(filePath, caption);
+}
+
+/** Whether Telegram credentials are present and the bot initialized. */
+export function isTelegramConfigured(): boolean {
+  return getTelegramNotifier().isConfigured();
 }
 
 async function openUrlInBrowser(url: string): Promise<void> {
@@ -168,7 +244,7 @@ export async function storeDb(urls: string[], openInBrowser: boolean = false, sk
   // Normal database storage mode
   return new Promise((resolve, reject) => {
     // Store database in data directory for persistence in Docker
-    const dbPath = process.env.NODE_ENV === 'production' ? './data/tori.db' : './tori.db';
+    const dbPath = getDbPath();
     const db = new Database(dbPath,
       OPEN_READWRITE | OPEN_CREATE,
       (err) => {
@@ -179,6 +255,21 @@ export async function storeDb(urls: string[], openInBrowser: boolean = false, sk
         }
 
         logger.info("Connected to Database");
+        db.serialize(() => {
+        // posts maps each Telegram message_id back to the job URL it announced,
+        // so the reaction listener can tie a 👍/❤️ on a post to its job posting.
+        db.run(`CREATE TABLE IF NOT EXISTS posts (
+          message_id INTEGER PRIMARY KEY,
+          url TEXT,
+          chat_id TEXT,
+          posted_at TEXT,
+          reaction_count INTEGER DEFAULT 0,
+          resume_status TEXT DEFAULT 'pending'
+        )`, (postsErr) => {
+          if (postsErr) {
+            logger.error("Error creating posts table", { error: postsErr.message });
+          }
+        });
         db.run("CREATE TABLE IF NOT EXISTS links (url TEXT UNIQUE)", (err) => {
           if (err) {
             logger.error("Error creating table", { error: err.message });
@@ -207,10 +298,25 @@ export async function storeDb(urls: string[], openInBrowser: boolean = false, sk
               } else {
                 logger.info("Added new URL to database", { url });
 
-                // Send notification for new URLs only using rate-limited system
-                const telegramPromise = getTelegramNotifier().sendMessage(url).catch((telegramError) => {
-                  logger.error("Failed to send Telegram notification", { url, error: telegramError instanceof Error ? telegramError.message : String(telegramError) });
-                });
+                // Send notification for new URLs only using rate-limited system.
+                // Record the resulting message_id so reactions on this post can
+                // later be mapped back to the job URL.
+                const telegramPromise = getTelegramNotifier().sendMessage(url)
+                  .then((messageId) => {
+                    if (messageId == null) return;
+                    db.run(
+                      "INSERT OR REPLACE INTO posts (message_id, url, chat_id, posted_at) VALUES (?, ?, ?, ?)",
+                      [messageId, url, process.env.TELEGRAM_CHAT_ID || null, new Date().toISOString()],
+                      (postErr) => {
+                        if (postErr) {
+                          logger.error("Failed to record post mapping", { url, messageId, error: postErr.message });
+                        }
+                      }
+                    );
+                  })
+                  .catch((telegramError) => {
+                    logger.error("Failed to send Telegram notification", { url, error: telegramError instanceof Error ? telegramError.message : String(telegramError) });
+                  });
                 asyncOperations.push(telegramPromise);
 
                 // Open URL in browser if flag is set
@@ -247,6 +353,7 @@ export async function storeDb(urls: string[], openInBrowser: boolean = false, sk
             });
           });
         });
+        }); // end db.serialize
       }
     );
   });

--- a/systemd/services/playwright-applications.service
+++ b/systemd/services/playwright-applications.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Playwright - Generate job applications for flagged Duunitori posts
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/mikko/ohjelmointi/github/playwright-crawlers
+EnvironmentFile=/opt/playwright-crawlers/.env
+Environment=NODE_ENV=production
+# Run sequentially: first drain Telegram replies/reactions to flag posts,
+# then generate applications for the flagged job postings. Type=oneshot runs
+# multiple ExecStart lines in order and waits for each to finish.
+ExecStart=/usr/bin/npx ts-node src/reaction_listener.ts
+ExecStart=/usr/bin/npx ts-node src/resume_generator.ts
+
+[Install]
+WantedBy=default.target

--- a/systemd/timers/playwright-applications.timer
+++ b/systemd/timers/playwright-applications.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily timer for job application generation
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+# Once a day at 07:00 local time. Persistent catches a missed run after downtime.
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+Unit=playwright-applications.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Reply `+` to a Duunitori job post in Telegram to flag it; a daily job then scrapes the posting plus the candidate CV and posts a tailored application back to the chat.

This was built and verified end-to-end against the live bot/DB (see Testing below).

## Changes

- **`utils.ts`**: `sendMessage` now returns the `message_id` and records a `message_id ↔ url` mapping in a new `posts` table. Adds `sendDocument`, shared send/token/db-path helpers. Accepts either `TELEGRAM_API_KEY` or `TELEGRAM_BOT_TOKEN` (they previously disagreed silently).
- **`reaction_listener.ts`** (`npm run reactions`): drains `getUpdates` and flags posts via **reply** (`+` flags, `-` un-flags — works in private DMs) or 👍/❤️ **reactions** (groups/channels only, bot must be admin).
- **`resume_generator.ts`** (`npm run resumes`): for flagged job posts, scrapes the job page + CV, tailors via the **Anthropic API** when `ANTHROPIC_API_KEY` is set (otherwise a fallback draft), saves markdown under `data/resumes/`, posts it to Telegram, and marks the post done. Skips non-job URLs (e.g. tori.fi listings).
- **`reactions_db.ts`**: shared promise-based DB helpers.
- **systemd**: daily oneshot service + timer running listener then generator in order.
- **`env.example` / `.gitignore`**: documents `ANTHROPIC_API_KEY`; ignores `data/resumes/`.

## Why reply instead of reactions

Telegram only delivers reaction updates when the bot is an **admin in a group/channel** — in a private DM, reactions are never reported (confirmed empirically). The configured chat is a DM, so a **reply** is the trigger. Reaction handling remains coded for if it ever moves to a group/channel.

## Testing

Verified live against the real bot and `data/tori.db`:
- Reply `+` to a job post → listener flags it (`matched`), `-` un-flags.
- Generator skips a flagged tori.fi marketplace item, generates + posts the draft for a flagged Duunitori job, marks it `done`.
- CV fetched from the IDN domain `viitamäki.fi`; job description scraped correctly.

## Deploy notes

- Install units: copy `systemd/services/playwright-applications.service` and `systemd/timers/playwright-applications.timer` to `/etc/systemd/system/`, `daemon-reload`, `enable --now playwright-applications.timer` (runs daily 07:00 EEST).
- Add `ANTHROPIC_API_KEY` to `/opt/playwright-crawlers/.env` for tailored applications (otherwise drafts are untailored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)